### PR TITLE
PM 14963 it s hard to write graphql expectations that look for multiple error messages

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,6 +2,7 @@ appraise "rails-7-0" do
   gem "rails", "7.0.8.6"
   gem "sprockets-rails", "3.5.2"
   gem "sqlite3", "~> 1.4"
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise "rails-7-1" do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-_none_
+**(Breaking)** Remove `have_graphql_error` RSpec matcher in favour of `have_graphql_errors` RSpec matcher
 
 ## 4.3.0 (2024-11-14)
 

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "rails", "7.0.8.6"
 gem "sprockets-rails", "3.5.2"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/lib/nulogy_graphql_api/rspec/graphql_matchers.rb
+++ b/lib/nulogy_graphql_api/rspec/graphql_matchers.rb
@@ -18,11 +18,15 @@ module NulogyGraphqlApi
       end
     end
 
-    RSpec::Matchers.define :have_graphql_error do |message|
+    RSpec::Matchers.define :have_graphql_errors do |*messages|
       match do |actual_response|
-        expect(actual_response.fetch(:errors, nil)).to contain_exactly(a_hash_including(
-          message: include(message)
-        ))
+        expect(actual_response.fetch(:errors, nil)).to contain_exactly(
+          *messages.map { |message|
+            a_hash_including(
+              message: include(message)
+            )
+          }
+        )
       end
     end
 

--- a/spec/requests/lib/nulogy_graphql_api/graphql_api_controller_spec.rb
+++ b/spec/requests/lib/nulogy_graphql_api/graphql_api_controller_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe DummyApiController, :graphql, type: :request do
     )
   end
 
+  it "returns graphql errors when requesting fields that do not exist" do
+    query = <<~GRAPHQL
+      query {
+        fakes {
+          missingField
+          anotherMissingField
+        }
+      }
+    GRAPHQL
+
+    post "/graphql_api/dummy_api/graphql", params: { query: query }
+
+    gql_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to_not be_successful
+    expect(gql_response).to have_graphql_errors(
+      "Field 'missingField' doesn't exist on type 'Fake'",
+      "Field 'anotherMissingField' doesn't exist on type 'Fake'"
+    )
+  end
+
   it "returns Not Found when requesting an entity that does not exist" do
     get "/graphql_api/dummy_api/test_record_not_found"
 


### PR DESCRIPTION
- **PM-14963: Replace have_graphql_error RSpec matcher with have_graphql_errors RSpec matcher that supports matching multiple error messages**
- **PM-14963: Pin concurrent-ruby for rails 7.0 to avoid errors when running appraisal**
